### PR TITLE
chore: use NotImplementedError instead of 'TODO'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,9 +146,6 @@ ignore = [
   "ISC001",   # Conflicts with formatter
   "RET505",   # I like my if (return) elif (return) else (return) pattern
   "PLR5501",  # I like my if (return) elif (return) else (return) pattern
-
-  "PT015",    # I'm using `assert False` for not-implemented FIXMEs
-  "B011",     # (can't use NotImplementedError because it's used to incidate abstract methods)
 ]
 isort.required-imports = ["from __future__ import annotations"]
 # Uncomment if using a _compat.typing backport

--- a/src/ragged/_spec_array_object.py
+++ b/src/ragged/_spec_array_object.py
@@ -217,7 +217,8 @@ class array:  # pylint: disable=C0103
                 cp = _import.cupy()
                 self._impl = cp.array(self._impl)
 
-        assert copy is None, "TODO"
+        if copy is not None:
+            raise NotImplementedError("TODO 1")  # noqa: EM101
 
     def __str__(self) -> str:
         """
@@ -289,7 +290,7 @@ class array:  # pylint: disable=C0103
         https://data-apis.org/array-api/latest/API_specification/generated/array_api.array.mT.html
         """
 
-        assert False, "TODO 1"
+        raise NotImplementedError("TODO 2")  # noqa: EM101
 
     @property
     def ndim(self) -> int:
@@ -352,7 +353,7 @@ class array:  # pylint: disable=C0103
         https://data-apis.org/array-api/latest/API_specification/generated/array_api.array.T.html
         """
 
-        assert False, "TODO 2"
+        raise NotImplementedError("TODO 3")  # noqa: EM101
 
     # methods: https://data-apis.org/array-api/latest/API_specification/array_object.html#methods
 
@@ -451,8 +452,7 @@ class array:  # pylint: disable=C0103
             https://data-apis.org/array-api/latest/API_specification/generated/array_api.array.__dlpack__.html
         """
 
-        assert stream, "TODO"
-        assert False, "TODO 9"
+        raise NotImplementedError("TODO 4")  # noqa: EM101
 
     def __dlpack_device__(self) -> tuple[enum.Enum, int]:
         """
@@ -464,7 +464,7 @@ class array:  # pylint: disable=C0103
             https://data-apis.org/array-api/latest/API_specification/generated/array_api.array.__dlpack_device__.html
         """
 
-        assert False, "TODO 10"
+        raise NotImplementedError("TODO 10")  # noqa: EM101
 
     def __eq__(self, other: int | float | bool | array, /) -> array:  # type: ignore[override]
         """
@@ -533,7 +533,7 @@ class array:  # pylint: disable=C0103
         https://data-apis.org/array-api/latest/API_specification/generated/array_api.array.__getitem__.html
         """
 
-        assert False, "TODO 15"
+        raise NotImplementedError("TODO 15")  # noqa: EM101
 
     def __gt__(self, other: int | float | array, /) -> array:
         """
@@ -641,7 +641,7 @@ class array:  # pylint: disable=C0103
         https://data-apis.org/array-api/latest/API_specification/generated/array_api.array.__matmul__.html
         """
 
-        assert False, "TODO 22"
+        raise NotImplementedError("TODO 22")  # noqa: EM101
 
     def __mod__(self, other: int | float | array, /) -> array:
         """
@@ -782,7 +782,7 @@ class array:  # pylint: disable=C0103
         https://data-apis.org/array-api/latest/API_specification/generated/array_api.array.__setitem__.html
         """
 
-        assert False, "TODO 31"
+        raise NotImplementedError("TODO 31")  # noqa: EM101
 
     def __sub__(self, other: int | float | array, /) -> array:
         """
@@ -852,7 +852,8 @@ class array:  # pylint: disable=C0103
 
         if isinstance(self._impl, ak.Array):
             if device != ak.backend(self._impl):
-                assert stream is None, "TODO"
+                if stream is not None:
+                    raise NotImplementedError("TODO 124")  # noqa: EM101
                 impl = ak.to_backend(self._impl, device)
             else:
                 impl = self._impl
@@ -860,7 +861,8 @@ class array:  # pylint: disable=C0103
         elif isinstance(self._impl, np.ndarray):
             # self._impl is a NumPy 0-dimensional array
             if device == "cuda":
-                assert stream is None, "TODO"
+                if stream is not None:
+                    raise NotImplementedError("TODO 125")  # noqa: EM101
                 cp = _import.cupy()
                 impl = cp.array(self._impl)
             else:

--- a/src/ragged/_spec_creation_functions.py
+++ b/src/ragged/_spec_creation_functions.py
@@ -53,12 +53,12 @@ def arange(
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.arange.html
     """
 
-    assert start, "TODO"
-    assert stop, "TODO"
-    assert step, "TODO"
-    assert dtype, "TODO"
-    assert device, "TODO"
-    assert False, "TODO 35"
+    start  # noqa: B018, pylint: disable=W0104
+    stop  # noqa: B018, pylint: disable=W0104
+    step  # noqa: B018, pylint: disable=W0104
+    dtype  # noqa: B018, pylint: disable=W0104
+    device  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 35")  # noqa: EM101
 
 
 def asarray(
@@ -112,6 +112,7 @@ def asarray(
 
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.asarray.html
     """
+
     return array(obj, dtype=dtype, device=device, copy=copy)
 
 
@@ -136,10 +137,10 @@ def empty(
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.empty.html
     """
 
-    assert shape, "TODO"
-    assert dtype, "TODO"
-    assert device, "TODO"
-    assert False, "TODO 36"
+    shape  # noqa: B018, pylint: disable=W0104
+    dtype  # noqa: B018, pylint: disable=W0104
+    device  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 36")  # noqa: EM101
 
 
 def empty_like(
@@ -161,10 +162,10 @@ def empty_like(
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.empty_like.html
     """
 
-    assert x, "TODO"
-    assert dtype, "TODO"
-    assert device, "TODO"
-    assert False, "TODO 37"
+    x  # noqa: B018, pylint: disable=W0104
+    dtype  # noqa: B018, pylint: disable=W0104
+    device  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 37")  # noqa: EM101
 
 
 def eye(
@@ -196,12 +197,12 @@ def eye(
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.eye.html
     """
 
-    assert n_rows, "TODO"
-    assert n_cols, "TODO"
-    assert k, "TODO"
-    assert dtype, "TODO"
-    assert device, "TODO"
-    assert False, "TODO 38"
+    n_rows  # noqa: B018, pylint: disable=W0104
+    n_cols  # noqa: B018, pylint: disable=W0104
+    k  # noqa: B018, pylint: disable=W0104
+    dtype  # noqa: B018, pylint: disable=W0104
+    device  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 38")  # noqa: EM101
 
 
 def from_dlpack(x: object, /) -> array:
@@ -217,8 +218,8 @@ def from_dlpack(x: object, /) -> array:
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.from_dlpack.html
     """
 
-    assert x, "TODO"
-    assert False, "TODO 39"
+    x  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 39")  # noqa: EM101
 
 
 def full(
@@ -253,11 +254,11 @@ def full(
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.full.html
     """
 
-    assert shape, "TODO"
-    assert fill_value, "TODO"
-    assert dtype, "TODO"
-    assert device, "TODO"
-    assert False, "TODO 40"
+    shape  # noqa: B018, pylint: disable=W0104
+    fill_value  # noqa: B018, pylint: disable=W0104
+    dtype  # noqa: B018, pylint: disable=W0104
+    device  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 40")  # noqa: EM101
 
 
 def full_like(
@@ -286,11 +287,11 @@ def full_like(
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.full_like.html
     """
 
-    assert x, "TODO"
-    assert fill_value, "TODO"
-    assert dtype, "TODO"
-    assert device, "TODO"
-    assert False, "TODO 41"
+    x  # noqa: B018, pylint: disable=W0104
+    fill_value  # noqa: B018, pylint: disable=W0104
+    dtype  # noqa: B018, pylint: disable=W0104
+    device  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 41")  # noqa: EM101
 
 
 def linspace(
@@ -343,13 +344,13 @@ def linspace(
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.linspace.html
     """
 
-    assert start, "TODO"
-    assert stop, "TODO"
-    assert num, "TODO"
-    assert dtype, "TODO"
-    assert device, "TODO"
-    assert endpoint, "TODO"
-    assert False, "TODO 42"
+    start  # noqa: B018, pylint: disable=W0104
+    stop  # noqa: B018, pylint: disable=W0104
+    num  # noqa: B018, pylint: disable=W0104
+    dtype  # noqa: B018, pylint: disable=W0104
+    device  # noqa: B018, pylint: disable=W0104
+    endpoint  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 42")  # noqa: EM101
 
 
 def meshgrid(*arrays: array, indexing: str = "xy") -> list[array]:
@@ -388,9 +389,9 @@ def meshgrid(*arrays: array, indexing: str = "xy") -> list[array]:
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.meshgrid.html
     """
 
-    assert arrays, "TODO"
-    assert indexing, "TODO"
-    assert False, "TODO 43"
+    arrays  # noqa: B018, pylint: disable=W0104
+    indexing  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 43")  # noqa: EM101
 
 
 def ones(
@@ -414,10 +415,10 @@ def ones(
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.ones.html
     """
 
-    assert shape, "TODO"
-    assert dtype, "TODO"
-    assert device, "TODO"
-    assert False, "TODO 44"
+    shape  # noqa: B018, pylint: disable=W0104
+    dtype  # noqa: B018, pylint: disable=W0104
+    device  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 44")  # noqa: EM101
 
 
 def ones_like(
@@ -440,10 +441,10 @@ def ones_like(
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.ones_like.html
     """
 
-    assert x, "TODO"
-    assert dtype, "TODO"
-    assert device, "TODO"
-    assert False, "TODO 45"
+    x  # noqa: B018, pylint: disable=W0104
+    dtype  # noqa: B018, pylint: disable=W0104
+    device  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 45")  # noqa: EM101
 
 
 def tril(x: array, /, *, k: int = 0) -> array:
@@ -466,9 +467,9 @@ def tril(x: array, /, *, k: int = 0) -> array:
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.tril.html
     """
 
-    assert x, "TODO"
-    assert k, "TODO"
-    assert False, "TODO 46"
+    x  # noqa: B018, pylint: disable=W0104
+    k  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 46")  # noqa: EM101
 
 
 def triu(x: array, /, *, k: int = 0) -> array:
@@ -491,9 +492,9 @@ def triu(x: array, /, *, k: int = 0) -> array:
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.triu.html
     """
 
-    assert x, "TODO"
-    assert k, "TODO"
-    assert False, "TODO 47"
+    x  # noqa: B018, pylint: disable=W0104
+    k  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 47")  # noqa: EM101
 
 
 def zeros(
@@ -517,10 +518,10 @@ def zeros(
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.zeros.html
     """
 
-    assert shape, "TODO"
-    assert dtype, "TODO"
-    assert device, "TODO"
-    assert False, "TODO 48"
+    shape  # noqa: B018, pylint: disable=W0104
+    dtype  # noqa: B018, pylint: disable=W0104
+    device  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 48")  # noqa: EM101
 
 
 def zeros_like(
@@ -543,7 +544,7 @@ def zeros_like(
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.zeros_like.html
     """
 
-    assert x, "TODO"
-    assert dtype, "TODO"
-    assert device, "TODO"
-    assert False, "TODO 49"
+    x  # noqa: B018, pylint: disable=W0104
+    dtype  # noqa: B018, pylint: disable=W0104
+    device  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 49")  # noqa: EM101

--- a/src/ragged/_spec_data_type_functions.py
+++ b/src/ragged/_spec_data_type_functions.py
@@ -34,10 +34,10 @@ def astype(x: array, dtype: Dtype, /, *, copy: bool = True) -> array:
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.astype.html
     """
 
-    assert x, "TODO"
-    assert dtype, "TODO"
-    assert copy, "TODO"
-    assert False, "TODO 50"
+    x  # noqa: B018, pylint: disable=W0104
+    dtype  # noqa: B018, pylint: disable=W0104
+    copy  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 50")  # noqa: EM101
 
 
 def can_cast(from_: Dtype | array, to: Dtype, /) -> bool:
@@ -56,9 +56,9 @@ def can_cast(from_: Dtype | array, to: Dtype, /) -> bool:
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.can_cast.html
     """
 
-    assert from_, "TODO"
-    assert to, "TODO"
-    assert False, "TODO 51"
+    from_  # noqa: B018, pylint: disable=W0104
+    to  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 51")  # noqa: EM101
 
 
 @dataclass
@@ -114,8 +114,8 @@ def finfo(type: Dtype | array, /) -> finfo_object:  # pylint: disable=W0622
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.finfo.html
     """
 
-    assert type, "TODO"
-    assert False, "TODO 52"
+    type  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 52")  # noqa: EM101
 
 
 @dataclass
@@ -155,8 +155,8 @@ def iinfo(type: Dtype | array, /) -> iinfo_object:  # pylint: disable=W0622
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.iinfo.html
     """
 
-    assert type, "TODO"
-    assert False, "TODO 53"
+    type  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 53")  # noqa: EM101
 
 
 def isdtype(dtype: Dtype, kind: Dtype | str | tuple[Dtype | str, ...]) -> bool:
@@ -199,9 +199,9 @@ def isdtype(dtype: Dtype, kind: Dtype | str | tuple[Dtype | str, ...]) -> bool:
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.isdtype.html
     """
 
-    assert dtype, "TODO"
-    assert kind, "TODO"
-    assert False, "TODO 54"
+    dtype  # noqa: B018, pylint: disable=W0104
+    kind  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 54")  # noqa: EM101
 
 
 def result_type(*arrays_and_dtypes: array | Dtype) -> Dtype:
@@ -218,5 +218,5 @@ def result_type(*arrays_and_dtypes: array | Dtype) -> Dtype:
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.result_type.html
     """
 
-    assert arrays_and_dtypes, "TODO"
-    assert False, "TODO 55"
+    arrays_and_dtypes  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 55")  # noqa: EM101

--- a/src/ragged/_spec_indexing_functions.py
+++ b/src/ragged/_spec_indexing_functions.py
@@ -37,7 +37,7 @@ def take(x: array, indices: array, /, *, axis: None | int = None) -> array:
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.take.html
     """
 
-    assert x, "TODO"
-    assert indices, "TODO"
-    assert axis, "TODO"
-    assert False, "TODO 109"
+    x  # noqa: B018, pylint: disable=W0104
+    indices  # noqa: B018, pylint: disable=W0104
+    axis  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 109")  # noqa: EM101

--- a/src/ragged/_spec_linear_algebra_functions.py
+++ b/src/ragged/_spec_linear_algebra_functions.py
@@ -73,9 +73,9 @@ def matmul(x1: array, x2: array, /) -> array:
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.matmul.html
     """
 
-    assert x1, "TODO"
-    assert x2, "TODO"
-    assert False, "TODO 110"
+    x1  # noqa: B018, pylint: disable=W0104
+    x2  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 110")  # noqa: EM101
 
 
 def matrix_transpose(x: array, /) -> array:
@@ -93,8 +93,8 @@ def matrix_transpose(x: array, /) -> array:
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.matrix_transpose.html
     """
 
-    assert x, "TODO"
-    assert False, "TODO 111"
+    x  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 111")  # noqa: EM101
 
 
 def tensordot(
@@ -140,10 +140,10 @@ def tensordot(
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.tensordot.html
     """
 
-    assert x1, "TODO"
-    assert x2, "TODO"
-    assert axes, "TODO"
-    assert False, "TODO 112"
+    x1  # noqa: B018, pylint: disable=W0104
+    x2  # noqa: B018, pylint: disable=W0104
+    axes  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 112")  # noqa: EM101
 
 
 def vecdot(x1: array, x2: array, /, *, axis: int = -1) -> array:
@@ -184,7 +184,7 @@ def vecdot(x1: array, x2: array, /, *, axis: int = -1) -> array:
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.vecdot.html
     """
 
-    assert x1, "TODO"
-    assert x2, "TODO"
-    assert axis, "TODO"
-    assert False, "TODO 113"
+    x1  # noqa: B018, pylint: disable=W0104
+    x2  # noqa: B018, pylint: disable=W0104
+    axis  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 113")  # noqa: EM101

--- a/src/ragged/_spec_manipulation_functions.py
+++ b/src/ragged/_spec_manipulation_functions.py
@@ -23,8 +23,8 @@ def broadcast_arrays(*arrays: array) -> list[array]:
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.broadcast_arrays.html
     """
 
-    assert arrays, "TODO"
-    assert False, "TODO 114"
+    arrays  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 114")  # noqa: EM101
 
 
 def broadcast_to(x: array, /, shape: tuple[int, ...]) -> array:
@@ -43,9 +43,9 @@ def broadcast_to(x: array, /, shape: tuple[int, ...]) -> array:
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.broadcast_to.html
     """
 
-    assert x, "TODO"
-    assert shape, "TODO"
-    assert False, "TODO 115"
+    x  # noqa: B018, pylint: disable=W0104
+    shape  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 115")  # noqa: EM101
 
 
 def concat(
@@ -71,9 +71,9 @@ def concat(
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.concat.html
     """
 
-    assert arrays, "TODO"
-    assert axis, "TODO"
-    assert False, "TODO 116"
+    arrays  # noqa: B018, pylint: disable=W0104
+    axis  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 116")  # noqa: EM101
 
 
 def expand_dims(x: array, /, *, axis: int = 0) -> array:
@@ -100,9 +100,9 @@ def expand_dims(x: array, /, *, axis: int = 0) -> array:
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.expand_dims.html
     """
 
-    assert x, "TODO"
-    assert axis, "TODO"
-    assert False, "TODO 117"
+    x  # noqa: B018, pylint: disable=W0104
+    axis  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 117")  # noqa: EM101
 
 
 def flip(x: array, /, *, axis: None | int | tuple[int, ...] = None) -> array:
@@ -124,9 +124,9 @@ def flip(x: array, /, *, axis: None | int | tuple[int, ...] = None) -> array:
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.flip.html
     """
 
-    assert x, "TODO"
-    assert axis, "TODO"
-    assert False, "TODO 118"
+    x  # noqa: B018, pylint: disable=W0104
+    axis  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 118")  # noqa: EM101
 
 
 def permute_dims(x: array, /, axes: tuple[int, ...]) -> array:
@@ -145,9 +145,9 @@ def permute_dims(x: array, /, axes: tuple[int, ...]) -> array:
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.permute_dims.html
     """
 
-    assert x, "TODO"
-    assert axes, "TODO"
-    assert False, "TODO 119"
+    x  # noqa: B018, pylint: disable=W0104
+    axes  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 119")  # noqa: EM101
 
 
 def reshape(x: array, /, shape: tuple[int, ...], *, copy: None | bool = None) -> array:
@@ -172,10 +172,10 @@ def reshape(x: array, /, shape: tuple[int, ...], *, copy: None | bool = None) ->
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.reshape.html
     """
 
-    assert x, "TODO"
-    assert shape, "TODO"
-    assert copy, "TODO"
-    assert False, "TODO 120"
+    x  # noqa: B018, pylint: disable=W0104
+    shape  # noqa: B018, pylint: disable=W0104
+    copy  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 120")  # noqa: EM101
 
 
 def roll(
@@ -213,10 +213,10 @@ def roll(
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.roll.html
     """
 
-    assert x, "TODO"
-    assert shift, "TODO"
-    assert axis, "TODO"
-    assert False, "TODO 121"
+    x  # noqa: B018, pylint: disable=W0104
+    shift  # noqa: B018, pylint: disable=W0104
+    axis  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 121")  # noqa: EM101
 
 
 def squeeze(x: array, /, axis: int | tuple[int, ...]) -> array:
@@ -234,9 +234,9 @@ def squeeze(x: array, /, axis: int | tuple[int, ...]) -> array:
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.squeeze.html
     """
 
-    assert x, "TODO"
-    assert axis, "TODO"
-    assert False, "TODO 122"
+    x  # noqa: B018, pylint: disable=W0104
+    axis  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 122")  # noqa: EM101
 
 
 def stack(arrays: tuple[array, ...] | list[array], /, *, axis: int = 0) -> array:
@@ -266,6 +266,6 @@ def stack(arrays: tuple[array, ...] | list[array], /, *, axis: int = 0) -> array
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.stack.html
     """
 
-    assert arrays, "TODO"
-    assert axis, "TODO"
-    assert False, "TODO 123"
+    arrays  # noqa: B018, pylint: disable=W0104
+    axis  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 123")  # noqa: EM101

--- a/src/ragged/_spec_searching_functions.py
+++ b/src/ragged/_spec_searching_functions.py
@@ -123,8 +123,8 @@ def nonzero(x: array, /) -> tuple[array, ...]:
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.nonzero.html
     """
 
-    assert x, "TODO"
-    assert False, "TODO 126"
+    x  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 126")  # noqa: EM101
 
 
 def where(condition: array, x1: array, x2: array, /) -> array:
@@ -146,7 +146,7 @@ def where(condition: array, x1: array, x2: array, /) -> array:
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.where.html
     """
 
-    assert condition, "TODO"
-    assert x1, "TODO"
-    assert x2, "TODO"
-    assert False, "TODO 127"
+    condition  # noqa: B018, pylint: disable=W0104
+    x1  # noqa: B018, pylint: disable=W0104
+    x2  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 127")  # noqa: EM101

--- a/src/ragged/_spec_set_functions.py
+++ b/src/ragged/_spec_set_functions.py
@@ -47,8 +47,8 @@ def unique_all(x: array, /) -> tuple[array, array, array, array]:
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.unique_all.html
     """
 
-    assert x, "TODO"
-    assert False, "TODO 128"
+    x  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 128")  # noqa: EM101
 
 
 unique_counts_result = namedtuple(  # pylint: disable=C0103
@@ -78,8 +78,8 @@ def unique_counts(x: array, /) -> tuple[array, array]:
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.unique_counts.html
     """
 
-    assert x, "TODO"
-    assert False, "TODO 129"
+    x  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 129")  # noqa: EM101
 
 
 unique_inverse_result = namedtuple(  # pylint: disable=C0103
@@ -109,8 +109,8 @@ def unique_inverse(x: array, /) -> tuple[array, array]:
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.unique_inverse.html
     """
 
-    assert x, "TODO"
-    assert False, "TODO 130"
+    x  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 130")  # noqa: EM101
 
 
 def unique_values(x: array, /) -> array:
@@ -129,5 +129,5 @@ def unique_values(x: array, /) -> array:
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.unique_values.html
     """
 
-    assert x, "TODO"
-    assert False, "TODO 131"
+    x  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 131")  # noqa: EM101

--- a/src/ragged/_spec_sorting_functions.py
+++ b/src/ragged/_spec_sorting_functions.py
@@ -34,11 +34,11 @@ def argsort(
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.argsort.html
     """
 
-    assert x, "TODO"
-    assert axis, "TODO"
-    assert descending, "TODO"
-    assert stable, "TODO"
-    assert False, "TODO 132"
+    x  # noqa: B018, pylint: disable=W0104
+    axis  # noqa: B018, pylint: disable=W0104
+    descending  # noqa: B018, pylint: disable=W0104
+    stable  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 132")  # noqa: EM101
 
 
 def sort(
@@ -66,8 +66,8 @@ def sort(
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.sort.html
     """
 
-    assert x, "TODO"
-    assert axis, "TODO"
-    assert descending, "TODO"
-    assert stable, "TODO"
-    assert False, "TODO 133"
+    x  # noqa: B018, pylint: disable=W0104
+    axis  # noqa: B018, pylint: disable=W0104
+    descending  # noqa: B018, pylint: disable=W0104
+    stable  # noqa: B018, pylint: disable=W0104
+    raise NotImplementedError("TODO 133")  # noqa: EM101


### PR DESCRIPTION
I resorted to `assert False, "TODO"` because I had been defining `ragged.array` as two classes with inheritance, and some linter thought that `raise NotImplementedError` meant that the subclass would have to override it. That's no longer true, so we can use `raise NotImplementedError`.

They still have unique identifiers, to make it easier to find (i.e. search code instead of reading the traceback).